### PR TITLE
Fix leak in DDHidEvent

### DIFF
--- a/DDHidLib/DDHidEvent.m
+++ b/DDHidLib/DDHidEvent.m
@@ -43,6 +43,12 @@
     return self;
 }
 
+- (void) dealloc;
+{
+    free(mEvent.longValue);
+    [super dealloc];
+}
+
 - (IOHIDElementType) type;
 {
     return mEvent.type;


### PR DESCRIPTION
This doesn't leak on every event, but quite a few keys do generate events with a long value set.

"If a long value is present, it is up to the caller to deallocate it", says the [documentation for IOHIDQueueInterface's getNextEvent method](https://developer.apple.com/library/mac/documentation/IOKit/Reference/IOHIDQueueInterface_reference/#//apple_ref/doc/uid/TP40012414-CLSCHIOHIDQueueInterface-DontLinkElementID_10).
