### PR TITLE
Fix memory leaks and integer mismatches identified by Clang static analyzer

### DIFF
--- a/DDHidLib/DDHidDevice.h
+++ b/DDHidLib/DDHidDevice.h
@@ -45,7 +45,7 @@
     BOOL mListenInExclusiveMode;
     DDHidQueue * mDefaultQueue;
     int mTag;
-    int mLogicalDeviceNumber;
+    NSUInteger mLogicalDeviceNumber;
 }
 
 - (id) initWithDevice: (io_object_t) device error: (NSError **) error;

--- a/DDHidLib/DDHidDevice.h
+++ b/DDHidLib/DDHidDevice.h
@@ -52,7 +52,7 @@
 - (id) initLogicalWithDevice: (io_object_t) device
          logicalDeviceNumber: (int) logicalDeviceNumber
                        error: (NSError **) error;
-- (int) logicalDeviceCount;
+- (NSUInteger) logicalDeviceCount;
 
 #pragma mark -
 #pragma mark Finding Devices

--- a/DDHidLib/DDHidDevice.m
+++ b/DDHidLib/DDHidDevice.m
@@ -287,7 +287,7 @@
     if ([self logicalDeviceCount] > 1)
     {
         productName = [productName stringByAppendingString:
-                       [NSString stringWithFormat:@" #%d", mLogicalDeviceNumber + 1]];
+                       [NSString stringWithFormat:@" #%lu", mLogicalDeviceNumber + 1]];
     }
     return productName;
 }

--- a/DDHidLib/DDHidDevice.m
+++ b/DDHidLib/DDHidDevice.m
@@ -169,7 +169,7 @@
     return devices;
 }
 
-- (int) logicalDeviceCount;
+- (NSUInteger) logicalDeviceCount;
 {
     return 1;
 }

--- a/DDHidLib/DDHidJoystick.h
+++ b/DDHidLib/DDHidJoystick.h
@@ -44,13 +44,13 @@
 #pragma mark -
 #pragma mark StickElements - indexed accessors
 
-- (unsigned int) countOfStickElements;
+- (NSUInteger) countOfStickElements;
 - (DDHidElement *) objectInStickElementsAtIndex: (unsigned int)index;
 
 #pragma mark -
 #pragma mark PovElements - indexed accessors
 
-- (unsigned int) countOfPovElements;
+- (NSUInteger) countOfPovElements;
 - (DDHidElement *) objectInPovElementsAtIndex: (unsigned int)index;
 
 - (NSArray *) allElements;
@@ -74,19 +74,19 @@
          logicalDeviceNumber: (int) logicalDeviceNumber 
                        error: (NSError **) error;
 
-- (int) logicalDeviceCount;
+- (NSUInteger) logicalDeviceCount;
 
 #pragma mark -
 #pragma mark Joystick Elements
 
-- (unsigned) numberOfButtons;
+- (NSUInteger) numberOfButtons;
 
 - (NSArray *) buttonElements;
 
 #pragma mark -
 #pragma mark Sticks - indexed accessors
 
-- (unsigned int) countOfSticks;
+- (NSUInteger) countOfSticks;
 - (DDHidJoystickStick *) objectInSticksAtIndex: (unsigned int)index;
 
 - (void) addElementsToQueue: (DDHidQueue *) queue;

--- a/DDHidLib/DDHidJoystick.m
+++ b/DDHidLib/DDHidJoystick.m
@@ -122,7 +122,7 @@
     mLogicalDeviceElements = [[NSMutableArray alloc] init];
 
     [self initLogicalDeviceElements];
-    int logicalDeviceCount = [mLogicalDeviceElements count];
+    NSUInteger logicalDeviceCount = [mLogicalDeviceElements count];
     if (logicalDeviceCount ==  0)
     {
         return nil;
@@ -151,7 +151,7 @@
     mButtonElements = nil;
 }
 
-- (int) logicalDeviceCount;
+- (NSUInteger) logicalDeviceCount;
 {
     return [mLogicalDeviceElements count];
 }
@@ -167,7 +167,7 @@
     return mButtonElements; 
 }
 
-- (unsigned) numberOfButtons;
+- (NSUInteger) numberOfButtons;
 {
     return [mButtonElements count];
 }
@@ -175,7 +175,7 @@
 #pragma mark -
 #pragma mark Sticks - indexed accessors
 
-- (unsigned int) countOfSticks 
+- (NSUInteger) countOfSticks 
 {
     return [mSticks count];
 }
@@ -351,11 +351,11 @@
             forElement: (DDHidElement *) element;
 {
     int normalizedUnits = DDHID_JOYSTICK_VALUE_MAX - DDHID_JOYSTICK_VALUE_MIN;
-    int elementUnits = [element maxValue] - [element minValue];
+    long elementUnits = [element maxValue] - [element minValue];
     
-    int normalizedValue = (((int64_t)(value - [element minValue]) * normalizedUnits) /
+    long normalizedValue = (((int64_t)(value - [element minValue]) * normalizedUnits) /
                            elementUnits) + DDHID_JOYSTICK_VALUE_MIN;
-    return normalizedValue;
+    return (int)normalizedValue;
 }
 
 - (int) povValue: (int) value
@@ -373,7 +373,7 @@
     
     // Do like DirectInput and express the hatswitch value in hundredths of a
 	// degree, clockwise from north.
-	return 36000 / (max - min + 1) * (value - min);
+    return (int)(36000 / (max - min + 1) * (value - min));
 }
 
 - (BOOL) findStick: (unsigned *) stick
@@ -613,7 +613,7 @@
 #pragma mark -
 #pragma mark mStickElements - indexed accessors
 
-- (unsigned int) countOfStickElements 
+- (NSUInteger) countOfStickElements
 {
     return [mStickElements count];
 }
@@ -626,7 +626,7 @@
 #pragma mark -
 #pragma mark PovElements - indexed accessors
 
-- (unsigned int) countOfPovElements;
+- (NSUInteger) countOfPovElements;
 {
     return [mPovElements count];
 }

--- a/DDHidLib/DDHidJoystick.m
+++ b/DDHidLib/DDHidJoystick.m
@@ -233,7 +233,7 @@
         if (usagePage == kHIDPage_GenericDesktop &&
             (usageId == kHIDUsage_GD_Joystick || usageId == kHIDUsage_GD_GamePad)) 
         {
-            [mLogicalDeviceElements addObject: [NSArray arrayWithObject: element]];
+            [mLogicalDeviceElements addObject: @[element]];
         }
     }
 }

--- a/DDHidLib/DDHidKeyboard.h
+++ b/DDHidLib/DDHidKeyboard.h
@@ -44,7 +44,7 @@
 
 - (NSArray *) keyElements;
 
-- (unsigned) numberOfKeys;
+- (NSUInteger) numberOfKeys;
 
 - (void) addElementsToQueue: (DDHidQueue *) queue;
 

--- a/DDHidLib/DDHidKeyboard.m
+++ b/DDHidLib/DDHidKeyboard.m
@@ -86,7 +86,7 @@
     return mKeyElements;
 }
 
-- (unsigned) numberOfKeys;
+- (NSUInteger) numberOfKeys;
 {
     return [mKeyElements count];
 }

--- a/DDHidLib/DDHidKeyboardBarcodeScanner.h
+++ b/DDHidLib/DDHidKeyboardBarcodeScanner.h
@@ -48,7 +48,7 @@
 
 - (NSArray *) keyElements;
 
-- (unsigned) numberOfKeys;
+- (NSUInteger) numberOfKeys;
 
 - (void) addElementsToQueue: (DDHidQueue *) queue;
 

--- a/DDHidLib/DDHidKeyboardBarcodeScanner.m
+++ b/DDHidLib/DDHidKeyboardBarcodeScanner.m
@@ -95,7 +95,7 @@
     return mKeyElements;
 }
 
-- (unsigned) numberOfKeys;
+- (NSUInteger) numberOfKeys;
 {
     return [mKeyElements count];
 }

--- a/DDHidLib/DDHidMouse.h
+++ b/DDHidLib/DDHidMouse.h
@@ -53,7 +53,7 @@
 
 - (NSArray *) buttonElements;
 
-- (unsigned) numberOfButtons;
+- (NSUInteger) numberOfButtons;
 
 - (void) addElementsToQueue: (DDHidQueue *) queue;
 

--- a/DDHidLib/DDHidMouse.m
+++ b/DDHidLib/DDHidMouse.m
@@ -117,7 +117,7 @@
     return mButtonElements; 
 }
 
-- (unsigned) numberOfButtons;
+- (NSUInteger) numberOfButtons;
 {
     return [mButtonElements count];
 }

--- a/DDHidLib/NSXReturnThrowError/NSXReturnThrowError.m
+++ b/DDHidLib/NSXReturnThrowError/NSXReturnThrowError.m
@@ -94,13 +94,16 @@ void NSXMakeErrorImp(const char *objCType_, intptr_t result_, const char *file_,
 	}
 
 	if (errorDomain) {
-		*error_ = [NSError errorWithDomain:errorDomain
-									  code:errorCode
-								  userInfo:@{
-											 @"reportingFile" : @(file_),
-											 @"reportingLine" : @(line_),
-											 @"reportingMethod" : @(function_),
-											 @"origin" : @(code_),
-											 }];
+        if (error_ != nil)
+        {
+            *error_ = [NSError errorWithDomain:errorDomain
+                                          code:errorCode
+                                      userInfo:@{
+                                                 @"reportingFile" : @(file_),
+                                                 @"reportingLine" : @(line_),
+                                                 @"reportingMethod" : @(function_),
+                                                 @"origin" : @(code_),
+                                                 }];
+        }
 	}
 }

--- a/DDHidLib/NSXReturnThrowError/NSXReturnThrowError.m
+++ b/DDHidLib/NSXReturnThrowError/NSXReturnThrowError.m
@@ -96,11 +96,11 @@ void NSXMakeErrorImp(const char *objCType_, intptr_t result_, const char *file_,
 	if (errorDomain) {
 		*error_ = [NSError errorWithDomain:errorDomain
 									  code:errorCode
-								  userInfo:[NSDictionary dictionaryWithObjectsAndKeys:
-									  [NSString stringWithUTF8String:file_],   @"reportingFile",
-									  [NSNumber numberWithInt:line_],   @"reportingLine",
-									  [NSString stringWithUTF8String:function_], @"reportingMethod",
-									  [NSString stringWithUTF8String:code_], @"origin",
-									  nil]];
+								  userInfo:@{
+											 @"reportingFile" : @(file_),
+											 @"reportingLine" : @(line_),
+											 @"reportingMethod" : @(function_),
+											 @"origin" : @(code_),
+											 }];
 	}
 }

--- a/FFHelperApp.m
+++ b/FFHelperApp.m
@@ -91,6 +91,7 @@ myCGEventCallback(CGEventTapProxy proxy, CGEventType type,
                 CGEventSourceRef sourceRef = CGEventCreateSourceFromEvent(ev);
                 CGEventRef newEvent = CGEventCreateKeyboardEvent(sourceRef, [regularKey intValue], keyState);
                 CFRelease(sourceRef);
+                CFAutorelease(newEvent);
                 return newEvent;
 			}
 		}
@@ -114,7 +115,6 @@ myCGEventCallback(CGEventTapProxy proxy, CGEventType type,
 					newE = [NSEvent otherEventWithType:NSSystemDefined location:[e locationInWindow] modifierFlags:([e modifierFlags] | ([e type] == NSKeyDown ? 0xa00 : 0xb00)) timestamp:[e timestamp] windowNumber:[e windowNumber] context:[e context] subtype:8 data1:(specialCode << 16) + (([e type] == NSKeyDown  ? 0x0a : 0x0b) << 8) data2:-1];
 				}
                 CGEventRef newEvent = [newE CGEvent];
-				CFRetain(newEvent); // newEvent gets released by the event system
 				return newEvent;
 			}
 		}
@@ -203,6 +203,9 @@ extern CFStringRef kAXTrustedCheckOptionPrompt __attribute__((weak_import));
   // Add to the current run loop.
   CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource,
 		     kCFRunLoopCommonModes);
+
+  // Source is retained by the run loop.
+  CFRelease(runLoopSource);
 
   // Enable the event tap.
   CGEventTapEnable(eventTap, true);

--- a/FFHelperApp.m
+++ b/FFHelperApp.m
@@ -157,7 +157,7 @@ extern CFStringRef kAXTrustedCheckOptionPrompt __attribute__((weak_import));
 
   if (AXIsProcessTrustedWithOptions != NULL) {
       // 10.9 or higher
-      NSDictionary *options = [NSDictionary dictionaryWithObjectsAndKeys:(id)kCFBooleanFalse, kAXTrustedCheckOptionPrompt, nil];
+      NSDictionary *options = @{ (__bridge NSString *)kAXTrustedCheckOptionPrompt : (id)kCFBooleanFalse };
       eventTapTest = CGEventTapCreate(kCGHIDEventTap, kCGHeadInsertEventTap, 0,
                                       eventMask, myCGEventCallback, NULL);
       if (!AXIsProcessTrustedWithOptions((__bridge CFDictionaryRef)options) || !eventTapTest) {

--- a/FFHelperAppController.m
+++ b/FFHelperAppController.m
@@ -55,7 +55,7 @@
 	NSURL *helperAppURL = [NSURL fileURLWithPath:[FFHelperAppController pathToHelperApp]];
 
 	unsigned options = NSWorkspaceLaunchWithoutAddingToRecents | NSWorkspaceLaunchWithoutActivation | NSWorkspaceLaunchAsync;
-	[[NSWorkspace sharedWorkspace] openURLs:[NSArray arrayWithObject:helperAppURL]
+	[[NSWorkspace sharedWorkspace] openURLs:@[helperAppURL]
 	                withAppBundleIdentifier:nil
 	                                options:options
 	         additionalEventParamDescriptor:nil

--- a/FFKeyLibrary.m
+++ b/FFKeyLibrary.m
@@ -29,66 +29,64 @@
 #include "NSDictionary+firstKeyForObject.h"
 #import "FFDefs.h"
 
-#define N(X) [NSNumber numberWithInt:X]
-
 static NSDictionary *keyDescriptions, *keyCodes, *specialCodes;
 
 @implementation FFKeyLibrary
 
 + (void)initialize {
-	keyDescriptions = [[NSDictionary alloc] initWithObjectsAndKeys:
-                       @"Brightness Down", N(NX_KEYTYPE_BRIGHTNESS_DOWN),
-                       @"Brightness Up", N(NX_KEYTYPE_BRIGHTNESS_UP),
-                       @"Brightness Down", N(KG_BRIGHTNESS_DOWN_KEY),
-                       @"Brightness Up", N(KG_BRIGHTNESS_UP_KEY),
-                       @"Toggle Illumination", N(NX_KEYTYPE_ILLUMINATION_TOGGLE),
-                       @"Illumination Down", N(NX_KEYTYPE_ILLUMINATION_DOWN),
-                       @"Illumination Up", N(NX_KEYTYPE_ILLUMINATION_UP),
-                       @"Rewind", N(NX_KEYTYPE_REWIND),
-                       @"Play/Pause", N(NX_KEYTYPE_PLAY),
-                       @"Fast-Forward", N(NX_KEYTYPE_FAST),
-                       @"Mute", N(NX_KEYTYPE_MUTE),
-                       @"Volume Down", N(NX_KEYTYPE_SOUND_DOWN),
-                       @"Volume Up", N(NX_KEYTYPE_SOUND_UP),
-                       @"Mirror Displays", N(NX_KEYTYPE_VIDMIRROR),
-                       @"Exposé", N(KG_EXPOSE_KEY),
-                       @"Dashboard", N(KG_DASHBOARD_KEY),
-                       @"Launchpad", N(KG_LAUNCHPAD_KEY),
-                       nil];
+	keyDescriptions = @{
+						@(NX_KEYTYPE_BRIGHTNESS_DOWN) : @"Brightness Down",
+						@(NX_KEYTYPE_BRIGHTNESS_UP) : @"Brightness Up",
+						@(KG_BRIGHTNESS_DOWN_KEY) : @"Brightness Down",
+						@(KG_BRIGHTNESS_UP_KEY) : @"Brightness Up",
+						@(NX_KEYTYPE_ILLUMINATION_TOGGLE) : @"Toggle Illumination",
+						@(NX_KEYTYPE_ILLUMINATION_DOWN) : @"Illumination Down",
+						@(NX_KEYTYPE_ILLUMINATION_UP) : @"Illumination Up",
+						@(NX_KEYTYPE_REWIND) : @"Rewind",
+						@(NX_KEYTYPE_PLAY) : @"Play/Pause",
+						@(NX_KEYTYPE_FAST) : @"Fast-Forward",
+						@(NX_KEYTYPE_MUTE) : @"Mute",
+						@(NX_KEYTYPE_SOUND_DOWN) : @"Volume Down",
+						@(NX_KEYTYPE_SOUND_UP) : @"Volume Up",
+						@(NX_KEYTYPE_VIDMIRROR) : @"Mirror Displays",
+						@(KG_EXPOSE_KEY) : @"Exposé",
+						@(KG_DASHBOARD_KEY) : @"Dashboard",
+						@(KG_LAUNCHPAD_KEY) : @"Launchpad",
+						};
 	
-	keyCodes = [[NSDictionary alloc] initWithObjectsAndKeys:
-                N(KG_KEY_F1), FF_F1_KEYID,
-                N(KG_KEY_F2), FF_F2_KEYID,
-                N(KG_KEY_F3), FF_F3_KEYID,
-                N(KG_KEY_F4), FF_F4_KEYID,
-                N(KG_KEY_F5), FF_F5_KEYID,
-                N(KG_KEY_F6), FF_F6_KEYID,
-                N(KG_KEY_F7), FF_F7_KEYID,
-                N(KG_KEY_F8), FF_F8_KEYID,
-                N(KG_KEY_F9), FF_F9_KEYID,
-                N(KG_KEY_F10), FF_F10_KEYID,
-                N(KG_KEY_F11), FF_F11_KEYID,
-                N(KG_KEY_F12), FF_F12_KEYID,
-                nil];
-	specialCodes = [[NSDictionary alloc] initWithObjectsAndKeys:
-                    N(NX_KEYTYPE_BRIGHTNESS_DOWN), FF_BRIGHTNESS_DOWN_ID_LAPTOP,
-                    N(NX_KEYTYPE_BRIGHTNESS_UP), FF_BRIGHTNESS_UP_ID_LAPTOP,
-                    N(KG_BRIGHTNESS_DOWN_KEY), FF_BRIGHTNESS_DOWN_ID_EXTERNAL,
-                    N(KG_BRIGHTNESS_UP_KEY), FF_BRIGHTNESS_UP_ID_EXTERNAL,
-                    N(NX_KEYTYPE_ILLUMINATION_TOGGLE), FF_ILLUMINATION_TOGGLE_ID,
-                    N(NX_KEYTYPE_ILLUMINATION_DOWN), FF_ILLUMINATION_DOWN_ID,
-                    N(NX_KEYTYPE_ILLUMINATION_UP), FF_ILLUMINATION_UP_ID,
-                    N(NX_KEYTYPE_REWIND), FF_REWIND_ID,
-                    N(NX_KEYTYPE_PLAY), FF_PLAYPAUSE_ID,
-                    N(NX_KEYTYPE_FAST), FF_FASTFORWARD_ID,
-                    N(NX_KEYTYPE_MUTE), FF_MUTE_ID,
-                    N(NX_KEYTYPE_SOUND_DOWN), FF_VOLUME_DOWN_ID,
-                    N(NX_KEYTYPE_SOUND_UP), FF_VOLUME_UP_ID,
-                    N(NX_KEYTYPE_VIDMIRROR), FF_VIDEO_MIRROR_ID,
-                    N(KG_EXPOSE_KEY), FF_EXPOSE_ID,
-                    N(KG_DASHBOARD_KEY), FF_DASHBOARD_ID,
-                    N(KG_LAUNCHPAD_KEY), FF_LAUNCHPAD_ID,
-                    nil];
+	keyCodes = @{
+				 FF_F1_KEYID : @(KG_KEY_F1),
+				 FF_F2_KEYID : @(KG_KEY_F2),
+				 FF_F3_KEYID : @(KG_KEY_F3),
+				 FF_F4_KEYID : @(KG_KEY_F4),
+				 FF_F5_KEYID : @(KG_KEY_F5),
+				 FF_F6_KEYID : @(KG_KEY_F6),
+				 FF_F7_KEYID : @(KG_KEY_F7),
+				 FF_F8_KEYID : @(KG_KEY_F8),
+				 FF_F9_KEYID : @(KG_KEY_F9),
+				 FF_F10_KEYID : @(KG_KEY_F10),
+				 FF_F11_KEYID : @(KG_KEY_F11),
+				 FF_F12_KEYID : @(KG_KEY_F12),
+				 };
+	specialCodes = @{
+					 FF_BRIGHTNESS_DOWN_ID_LAPTOP : @(NX_KEYTYPE_BRIGHTNESS_DOWN),
+					 FF_BRIGHTNESS_UP_ID_LAPTOP : @(NX_KEYTYPE_BRIGHTNESS_UP),
+					 FF_BRIGHTNESS_DOWN_ID_EXTERNAL : @(KG_BRIGHTNESS_DOWN_KEY),
+					 FF_BRIGHTNESS_UP_ID_EXTERNAL : @(KG_BRIGHTNESS_UP_KEY),
+					 FF_ILLUMINATION_TOGGLE_ID : @(NX_KEYTYPE_ILLUMINATION_TOGGLE),
+					 FF_ILLUMINATION_DOWN_ID : @(NX_KEYTYPE_ILLUMINATION_DOWN),
+					 FF_ILLUMINATION_UP_ID : @(NX_KEYTYPE_ILLUMINATION_UP),
+					 FF_REWIND_ID : @(NX_KEYTYPE_REWIND),
+					 FF_PLAYPAUSE_ID : @(NX_KEYTYPE_PLAY),
+					 FF_FASTFORWARD_ID : @(NX_KEYTYPE_FAST),
+					 FF_MUTE_ID : @(NX_KEYTYPE_MUTE),
+					 FF_VOLUME_DOWN_ID : @(NX_KEYTYPE_SOUND_DOWN),
+					 FF_VOLUME_UP_ID : @(NX_KEYTYPE_SOUND_UP),
+					 FF_VIDEO_MIRROR_ID : @(NX_KEYTYPE_VIDMIRROR),
+					 FF_EXPOSE_ID : @(KG_EXPOSE_KEY),
+					 FF_DASHBOARD_ID : @(KG_DASHBOARD_KEY),
+					 FF_LAUNCHPAD_ID : @(KG_LAUNCHPAD_KEY),
+					 };
 }
 
 /*

--- a/FFKeyboard.m
+++ b/FFKeyboard.m
@@ -55,6 +55,7 @@ static NSMutableDictionary *keyboards;
 		CFStringRef fnusagemap = IORegistryEntrySearchCFProperty([self.device ioDevice], kIOServicePlane, (CFStringRef)@"FnFunctionUsageMap", kCFAllocatorDefault, kIORegistryIterateRecursively);
 		if(fnusagemap) { // if we've got a non-special keyboard, this won't be set
 			NSArray *codes = [(__bridge NSString *)fnusagemap componentsSeparatedByString:@","];
+            CFRelease(fnusagemap);
 			NSMutableArray *fkeyCodes = [NSMutableArray array];
 			NSMutableArray *specialCodes = [NSMutableArray array];
 			NSInteger index = 0;

--- a/FunctionFlip.xcodeproj/project.pbxproj
+++ b/FunctionFlip.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 1030;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "FunctionFlip" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/FunctionFlip.xcodeproj/project.pbxproj
+++ b/FunctionFlip.xcodeproj/project.pbxproj
@@ -614,7 +614,6 @@
 					"$(inherited)",
 					"\"$(SRCROOT)\"",
 				);
-				GCC_ENABLE_OBJC_GC = unsupported;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = FunctionFlip_Prefix.pch;

--- a/USBNotifier.m
+++ b/USBNotifier.m
@@ -64,10 +64,14 @@ static void usbDeviceRemoved(void *refCon, io_iterator_t iterator) {
 		CFStringRef deviceName = CFStringCreateWithCString(kCFAllocatorDefault,
 														   deviceNameChars,
 														   kCFStringEncodingASCII);
-		if (CFStringCompare(deviceName, CFSTR("OHCI Root Hub Simulation"), 0) == kCFCompareEqualTo)
+        if (CFStringCompare(deviceName, CFSTR("OHCI Root Hub Simulation"), 0) == kCFCompareEqualTo) {
+            CFRelease(deviceName);
 			deviceName = CFCopyLocalizedString(CFSTR("USB Bus"), "");
-		else if (CFStringCompare(deviceName, CFSTR("EHCI Root Hub Simulation"), 0) == kCFCompareEqualTo)
+        }
+        else if (CFStringCompare(deviceName, CFSTR("EHCI Root Hub Simulation"), 0) == kCFCompareEqualTo) {
+            CFRelease(deviceName);
 			deviceName = CFCopyLocalizedString(CFSTR("USB 2.0 Bus"), "");
+        }
 
 		// NSLog(@"USB Device Detached: %@" , deviceName);
 		[(__bridge FFHelperApp *)refCon keyboardListChanged];


### PR DESCRIPTION
Also modernized some Obj-C syntax.

Might address some of the leaks causing #9, but I haven't tested it. Not sure what the best way to profile the app is, since I don't understand the relationship between the preference pane and the helper. If you can tell me how to run in Instruments, I'd be happy to give it a look.

Static analysis warnings I didn't fix:
- non-localized strings
- unused variables. They aren't causing leaks, but I'd like to delete them if they really are just dead code.
- All three calls to `+[DDHidDevice allDevicesMatchingCFDictionary:withClass:skipZeroLocations:]`. The static analyzer complains that the match dictionary that is passed in may be leaked. However, the dictionary is passed to `IOServiceGetMatchingServices`, which is documented to consume (i.e. release) the dictionary that is passed in. Not sure how to suppress the static analyzer, but as I understand it, this is not actually leaking.